### PR TITLE
GenerateToken() now properly creates scoped API tokens

### DIFF
--- a/api_client.go
+++ b/api_client.go
@@ -94,6 +94,9 @@ func (client *ApiClient) GenerateToken() (string, error) {
 	}
 	request.Header.Set("Authorization", client.apiKey)
 
+	// Tenant scoping like {"tenant_id": 123} is ignored if Content-Type not set to "application/json"
+	request.Header.Set("Content-Type", "application/json")
+
 	// Fire the request
 	resp, err := client.do(request, false)
 	if err != nil {

--- a/api_client_http_test.go
+++ b/api_client_http_test.go
@@ -50,6 +50,7 @@ func TestGenerateToken(t *testing.T) {
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "/tokens/generate", r.URL.Path)
 			assert.Equal(t, "test-api-key", r.Header.Get("Authorization"))
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 			w.Write([]byte(`{"token":"test-api-token"}`))
 		}),
 	)


### PR DESCRIPTION
## Issue

The `Content-Type: application/json` HTTP request header is not set in `GenerateToken()` in `api_client.go`. As a result, when `GenerateToken()` makes a HTTP request to `/POST /tokens/generate`, the JSON HTTP request body is ignored by the server (e.g. `{"tenant_id": 123}`), and an API Token IS retrieved, but the token has default scope, instead of the specified scope in the JSON body.

This issue appears to only impact GoLang clients which call `NewApiClient()` with the `WithTenantId()` argument (scoped clients).

## Re-creating the issue

1. Create a new client with `flareio.NewApiClient()`. Be sure to use the `flareio.WithTenantId(TENANT_ID)` option, like below, and **make sure to scope the client to a non-default Tenant ID**, like below:

```
client := flareio.NewApiClient(
		SOME_API_KEY,
		flareio.WithTenantId(123),
)
```
2. Using the API token created by the client, call `/GET /tokens/test` and make note of the `tenant_id` that is returned
3. Try my patched code and again, make note of the `tenant_id` that is returned

## Impact

1. Requests made to tenant-scoped endpoints like `/POST /leaksdb/v2/credentials/_search` will return results for the default tenant instead of the intended tenant. This may cause erroneous data to be stored by customers.
